### PR TITLE
Add Modal for Sub Confirm Page

### DIFF
--- a/controller/main_controller.php
+++ b/controller/main_controller.php
@@ -291,6 +291,11 @@ class main_controller
 			'U_PPSDK'	=> $u_ppsdk,
 		));
 
+		if ($this->request->is_ajax())
+		{
+			confirm_box(false, ['GROUPSUB_CONFIRM', $term['package']->get_name()], '', 'select_term.html');
+		}
+
 		return $this->helper->render('@stevotvr_groupsub/select_term.html', $term['package']->get_name());
 	}
 }

--- a/styles/all/template/package_list.html
+++ b/styles/all/template/package_list.html
@@ -20,6 +20,16 @@
 
 {% endif %}
 
+{% if package|length > 1 %}
+	<script>
+		var stevotvr_groupsub_term_href = '{{ U_ACTION }}?term_id=';
+		function stevotvr_groupsub_set_term_id(el, id)
+		{
+			document.getElementById(id).href = stevotvr_groupsub_term_href + el.value;
+		}
+	</script>
+{% endif %}
+
 {% for p in package %}
 
 <div class="panel bg{% if loop.index is odd %}1{% else %}2{% endif %}">
@@ -59,7 +69,7 @@
 		{% endfor %}
 	{% elseif p.term|length > COLLAPSE_TERMS %}
 					<p>
-						<select name="term_id">
+						<select name="term_id" onchange="stevotvr_groupsub_set_term_id(this, 'pkg{{ p.ID }}')">
 		{% for t in p.term %}
 							<option value="{{ t.ID }}">{{ t.PRICE }} / {% if t.LENGTH %}{{ t.LENGTH }}{% else %}{{ lang('GROUPSUB_LENGTH_UNLIMITED') }}{% endif %}</option>
 		{% endfor %}
@@ -68,15 +78,15 @@
 	{% else %}
 					<p>
 		{% for t in p.term %}
-						<label><input type="radio" name="term_id" value="{{ t.ID }}">{{ t.PRICE }} / {% if t.LENGTH %}{{ t.LENGTH }}{% else %}<b>{{ lang('GROUPSUB_LENGTH_UNLIMITED') }}</b>{% endif %}</label><br>
+						<label><input type="radio" name="term_id" value="{{ t.ID }}" onclick="stevotvr_groupsub_set_term_id(this, 'pkg{{ p.ID }}')">{{ t.PRICE }} / {% if t.LENGTH %}{{ t.LENGTH }}{% else %}<b>{{ lang('GROUPSUB_LENGTH_UNLIMITED') }}</b>{% endif %}</label><br>
 		{% endfor %}
 					</p>
 	{% endif %}
 	{% if p.S_ACTIVE %}
 					<p{% if p.S_WARNING %} style="color: #f00"{% endif %}>{% if p.EXPIRES %}{{ lang('GROUPSUB_SUBSCRIBED_UNTIL', p.EXPIRES) }}{% else %}{{ lang('GROUPSUB_SUBSCRIBED') }}{% endif %}</p>
-					{% if p.EXPIRES %}<input class="button1" type="submit" name="submit" value="{{ lang('GROUPSUB_RENEW') }}">{% endif %}
+					{% if p.EXPIRES %}<a id="pkg{{ p.ID }}" href="{{ U_ACTION }}{% if p.term|length == 1 %}?term_id={{ p.term[0].ID }}{% endif %}" class="button1" data-ajax="true" data-refresh="true">{{ lang('GROUPSUB_RENEW') }}</a>{% endif %}
 	{% else %}
-					<input class="button1" type="submit" name="submit" value="{{ lang('GROUPSUB_SUBSCRIBE') }}">
+					<a id="pkg{{ p.ID }}" href="{{ U_ACTION }}{% if p.term|length == 1 %}?term_id={{ p.term[0].ID }}{% endif %}" class="button1" data-ajax="true" data-refresh="true">{{ lang('GROUPSUB_SUBSCRIBE') }}</a>
 	{% endif %}
 				</fieldset>
 			</form>

--- a/styles/all/template/select_term.html
+++ b/styles/all/template/select_term.html
@@ -1,3 +1,39 @@
+{% if S_AJAX_REQUEST %}
+
+<form action="https://www.{% if S_PP_SANDBOX %}sandbox.{% endif %}paypal.com/cgi-bin/webscr" method="post">
+	<h3>{{ lang('GROUPSUB_CONFIRM', PKG_NAME) }}</h3>
+	<dl class="details">
+		<dt>{{ lang('GROUPSUB_SUBSCRIPTION') ~ lang('COLON') }}</dt>
+		<dd>{{ PKG_NAME }}</dd>
+		<dt>{{ lang('GROUPSUB_PRICE') ~ lang('COLON') }}</dt>
+		<dd>{{ TERM_PRICE }}</dd>
+		<dt>{{ lang('GROUPSUB_LENGTH') ~ lang('COLON') }}</dt>
+		<dd>{% if TERM_LENGTH %}{{ TERM_LENGTH }}{% else %}<b>{{ lang('GROUPSUB_LENGTH_UNLIMITED') }}</b>{% endif %}</dd>
+	</dl>
+	<hr>
+	<fieldset class="submit-buttons">
+{% if PP_ENABLED %}
+		<noscript><p class="error">{{ lang('GROUPSUB_JS_REQUIRED') }}</p></noscript>
+		<script>paypal_button_config = {{ PAYPAL_CONFIG|raw }};</script>
+		<div id="paypal-button-container"></div>
+		{% if not INCLUDED_PAYPALSDKJS %}
+			{% INCLUDEJS U_PPSDK %}
+			{% DEFINE INCLUDED_PAYPALSDKJS = true %}
+		{% endif %}
+		{% INCLUDEJS '@stevotvr_groupsub/paypal_buttons.js' %}
+{% endif %}
+		<a href="{{ U_ACTION }}" class="button2">{{ lang('CANCEL') }}</a>
+	</fieldset>
+
+	<fieldset id="paypal-success" style="display: none;">
+		<p>{{ lang('GROUPSUB_RETURN_MESSAGE', PKG_NAME, TERM_LENGTH) }}</p>
+	</fieldset>
+</form>
+
+
+{% else %}
+
+
 {% include 'overall_header.html' %}
 
 <form action="https://www.{% if S_PP_SANDBOX %}sandbox.{% endif %}paypal.com/cgi-bin/webscr" method="post">
@@ -108,3 +144,5 @@
 </form>
 
 {% include 'overall_footer.html' %}
+
+{% endif %}


### PR DESCRIPTION
Fix #2 

Add Modal for Group Subscription Confirm Page

I have tested this on Group Subscription v`1.2.0-beta`,
I have done the required changes for Group Subscription v`1.3.0-beta4`,
hence kindly do a through check/test for Group Subscription v`1.3.0-beta4`.

You can do further changes as-per your wish,
like JavaScript changes for `stevotvr_groupsub_set_term_id(...)` function, ...etc...

Best regards 👍 
